### PR TITLE
Update getGlobalInfluenceM.m

### DIFF
--- a/IMRTP/getGlobalInfluenceM.m
+++ b/IMRTP/getGlobalInfluenceM.m
@@ -49,6 +49,8 @@ if length(structsV) == 1
 else
 
    global planC;
+   
+   indexS = planC{end};
 
    beamlets = [IM.beams(:).beamlets];
    
@@ -65,17 +67,19 @@ else
 
    %Find minimum number of nonzero elements that need to be put in influenceM.
    for structNum = structsV;
-       strBmletInd = find(structNum==structIndV);
+       c = find(structNum==structIndV);
         count = 0;
-        for i=1:length(beamlets(structNum,:))
+        for i=1:length(beamlets(strBmletInd,:))
             count = count + length(beamlets(strBmletInd,i).influence);
         end
         nnzV(structNum) = count;
    end
     maxnnz = max(nnzV);
-
+    
+    numVoxels = prod(getUniformScanSize(planC{indexS.scan}(getStructureAssociatedScan(structsV(1)))));
+    
     %Pre-initalize influence matrix, greatly speeds things up.
-    influenceM = spalloc(getUniformScanSize(planC{indexS.scan}(getStructureAssociatedScan(structsV(1)))), numPBs, maxnnz);
+    influenceM = spalloc(numVoxels, numPBs, maxnnz);
 
     %Make sure structsV is a row vector, used in below for loop.
     if size(structsV, 1) ~= 1


### PR DESCRIPTION
This routine is buggy in the part executed when passing more than one structure in structsV.

Proposed changes:
1) strBmletInd index should be used instead of structNum
2) computing indexS = planC{end} was missing.
3) influenceM = spalloc(numVoxels, numPBs, maxnnz), where numVoxels = prod(getUniformScanSize(planC{indexS.scan}(getStructureAssociatedScan(structsV(1))))) was missing.

BTW, this routine needs to be further debugged in the final part where the sparse influence matrix is populated.
Indeed, I observed unespected discrepancies when computing the dose of one ROI (using getSingleGlobalInfluenceM()) vs. extrapolating the very same ROI's dose from the global dose computed over more ROIs. 
These are very small discrepacies, which are not expected, I double checked the correct sampling rate was used on both tests.
Please debug and fix the cause. I am still investigating the cause.

P.S. could you accept my invitation to join the CERR google group (my email: alfonsoisola@gmail.com).

Regards, Alfonso

Regards.