### PR TITLE
Fixes viewer problem in MATLAB 2015b

### DIFF
--- a/CERR_core/Viewers/showCT.m
+++ b/CERR_core/Viewers/showCT.m
@@ -344,5 +344,5 @@ end
 if nargout > 0
     varargout{1} = hImage;
 else
-    varargout = [];
+    varargout = {};
 end


### PR DESCRIPTION
Later versions of MATLAB complain that varargout must return a cell array. This prevents callbacks from completing successfully, so the CERR viewer fails.